### PR TITLE
fix devcontainer installs to vscode user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 #   rm -rf /var/lib/apt/lists/*
 # EOF
 
+USER vscode
 RUN <<EOF
- curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
- curl -LsSf https://astral.sh/uv/install.sh | sh
+  curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
+  curl -LsSf https://astral.sh/uv/install.sh | sh
 EOF

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     "vscode": {
       "extensions": [
         "rust-lang.rust-analyzer",
-        "ms-python.python"
+        "ms-python.python",
+        "charliermarsh.ruff"
       ]
     }
   }


### PR DESCRIPTION
Avoids having to setup path, making uv and ruff available.

Also added ruff to devcontainer extensions