### PR TITLE
dependencies update: rand, rand_distr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,8 +352,8 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
- "rand",
- "rand_distr",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
  "rayon",
  "reborrow",
  "serde",
@@ -623,7 +623,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -888,7 +900,7 @@ dependencies = [
  "noisy_float",
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -929,7 +941,7 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1099,7 +1111,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1164,8 +1176,8 @@ dependencies = [
  "ordered-float",
  "pymoors_macros",
  "pyo3",
- "rand",
- "rand_distr",
+ "rand 0.9.0",
+ "rand_distr 0.5.1",
  "rayon",
  "rstest",
 ]
@@ -1252,14 +1264,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1269,7 +1298,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1278,7 +1317,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -1288,7 +1336,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -1624,6 +1682,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,13 +1841,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -1788,6 +1873,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ python-source = "python"
 [dependencies]
 pyo3 = { version = "0.23.5", features = ["multiple-pymethods"]}
 numpy = "0.23.0"
-rand = "0.8.5"
+rand = "0.9.0"
+rand_distr = "0.5.1"
 num-traits = "0.2.19"
 ndarray = "0.16.1"
 ordered-float = "4.6.0"
-rand_distr = "0.4.3"
 rayon = "1.10.0"
 ndarray-stats = "0.6.0"
 pymoors_macros = { path = "pymoors_macros"}

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -201,7 +201,13 @@ impl MultiObjectiveAlgorithm {
         }
 
         let mut rng =
-            MOORandomGenerator::new(seed.map_or_else(StdRng::from_entropy, StdRng::seed_from_u64));
+        MOORandomGenerator::new(
+            seed.map_or_else(
+                || StdRng::from_rng(&mut rand::rng()), 
+                StdRng::seed_from_u64
+            )
+        );
+        
         let mut genes = sampler.operate(population_size, n_vars, &mut rng);
 
         // Create the evolution operator.

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,33 +1,36 @@
+use std::usize;
+
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, RngCore, SeedableRng};
+use rand::prelude::IndexedRandom;
 
 /// A trait defining a unified interface for generating random values,
 /// used across genetic operators and algorithms.
 pub trait RandomGenerator {
     /// Generates a random `usize` in the range `[min, max)` using the underlying RNG.
     fn gen_range_usize(&mut self, min: usize, max: usize) -> usize {
-        self.rng().gen_range(min..max)
+        self.rng().random_range(min..max)
     }
 
     /// Generates a random `f64` in the range `[min, max)` using the underlying RNG.
     fn gen_range_f64(&mut self, min: f64, max: f64) -> f64 {
-        self.rng().gen_range(min..max)
+        self.rng().random_range(min..max)
     }
 
     /// Generates a random `usize` using the underlying RNG.
     fn gen_usize(&mut self) -> usize {
-        self.rng().gen()
+        self.rng().random_range(usize::MIN..usize::MAX)
     }
-
+    
     /// Generates a random boolean value with probability `p` of being `true`
     /// using the underlying RNG.
     fn gen_bool(&mut self, p: f64) -> bool {
-        self.rng().gen_bool(p)
+        self.rng().random_bool(p)
     }
     /// Generates a random probability as an `f64` in the range `[0.0, 1.0)`.
     fn gen_proability(&mut self) -> f64 {
-        self.rng().gen::<f64>()
+        self.rng().random::<f64>()
     }
     fn shuffle_vec(&mut self, vector: &mut Vec<f64>) {
         vector.shuffle(self.rng())
@@ -54,9 +57,13 @@ impl MOORandomGenerator {
         Self { rng }
     }
     pub fn new_from_seed(seed: Option<u64>) -> Self {
-        let rng = seed.map_or_else(StdRng::from_entropy, StdRng::seed_from_u64);
+        let rng = seed.map_or_else(
+            || StdRng::from_rng(&mut rand::rng()),
+            StdRng::seed_from_u64
+        );
         Self { rng }
     }
+    
 }
 
 impl RandomGenerator for MOORandomGenerator {
@@ -88,10 +95,10 @@ impl RngCore for TestDummyRng {
         unimplemented!("Not used in this test")
     }
 
-    /// Not used in tests. This method is unimplemented.
-    fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand::Error> {
-        unimplemented!("Not used in this test")
-    }
+    // Not used in tests. This method is unimplemented.
+    //fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand::Error> {
+    //    unimplemented!("Not used in this test")
+    //}
 }
 
 pub struct NoopRandomGenerator {


### PR DESCRIPTION
# Update project for Rust 2024 Edition compatibility

This PR updates the codebase to be compatible with the Rust 2024 Edition.

## Changes made:

1. Updated `rand` and `rand_distr` dependencies to their latest versions
   - This prevents future conflicts with the new `gen` keyword introduced in Rust 2024
   - Replaced deprecated `from_entropy()` calls with the recommended `from_rng()` alternative

## Rationale:

The Rust 2024 Edition introduces a new `gen` keyword that conflicts with functions in older versions of the rand ecosystem. By updating these dependencies now, we can ensure a smoother transition when upgrading to Rust 2024 Edition.

Let me know if you have any questions or would like me to make any adjustments!