### PR TITLE
Replace imports from numpy to ndarray

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::{concatenate, Axis};
+use ndarray::{concatenate, Axis};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::error::Error;
@@ -203,11 +203,11 @@ impl MultiObjectiveAlgorithm {
         let mut rng =
         MOORandomGenerator::new(
             seed.map_or_else(
-                || StdRng::from_rng(&mut rand::rng()), 
+                || StdRng::from_rng(&mut rand::rng()),
                 StdRng::seed_from_u64
             )
         );
-        
+
         let mut genes = sampler.operate(population_size, n_vars, &mut rng);
 
         // Create the evolution operator.

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use numpy::ndarray::Axis;
+use ndarray::Axis;
 
 use crate::genetic::{Population, PopulationConstraints, PopulationFitness, PopulationGenes};
 
@@ -122,7 +122,7 @@ impl Evaluator {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use numpy::ndarray::{array, concatenate, Axis};
+    use ndarray::{array, concatenate, Axis};
 
     // Fitness function: Sphere function (sum of squares for each individual).
     fn fitness_fn(genes: &PopulationGenes) -> PopulationFitness {

--- a/src/genetic.rs
+++ b/src/genetic.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::{concatenate, Array1, Array2, ArrayViewMut1, Axis};
+use ndarray::{concatenate, Array1, Array2, ArrayViewMut1, Axis};
 
 /// Represents an individual in the population.
 /// Each `IndividualGenes` is an `Array1<f64>`.

--- a/src/helpers/extreme_points.rs
+++ b/src/helpers/extreme_points.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::{Array1, Axis};
+use ndarray::{Array1, Axis};
 
 use crate::genetic::PopulationFitness;
 

--- a/src/helpers/printer.rs
+++ b/src/helpers/printer.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::Axis;
+use ndarray::Axis;
 
 use crate::genetic::Population;
 

--- a/src/non_dominated_sorting/dominator.rs
+++ b/src/non_dominated_sorting/dominator.rs
@@ -160,7 +160,7 @@ pub fn build_fronts(population: Population, n_survive: usize) -> Fronts {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use numpy::ndarray::{array, Array2};
+    use ndarray::{array, Array2};
 
     #[test]
     fn test_dominates() {

--- a/src/operators/crossover/exponential.rs
+++ b/src/operators/crossover/exponential.rs
@@ -85,7 +85,7 @@ impl CrossoverOperator for ExponentialCrossover {
 mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use numpy::ndarray::array;
+    use ndarray::array;
 
     /// A simple fake random generator for controlled testing of ExponentialCrossover.
     /// It returns predetermined values for `gen_range_usize` and `gen_proability`.

--- a/src/operators/crossover/order.rs
+++ b/src/operators/crossover/order.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::Array1;
+use ndarray::Array1;
 use pymoors_macros::py_operator;
 
 use crate::genetic::IndividualGenes;
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use crate::genetic::IndividualGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use numpy::ndarray::Array1;
+    use ndarray::Array1;
     use rand::RngCore;
 
     /// A controlled fake RandomGenerator that returns predetermined values for `gen_range_usize`.

--- a/src/operators/crossover/single_point.rs
+++ b/src/operators/crossover/single_point.rs
@@ -1,4 +1,4 @@
-use numpy::ndarray::{concatenate, s, Array1, Axis};
+use ndarray::{concatenate, s, Array1, Axis};
 use pymoors_macros::py_operator;
 
 use crate::genetic::IndividualGenes;
@@ -64,8 +64,8 @@ impl CrossoverOperator for SinglePointBinaryCrossover {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use numpy::ndarray::array;
-    use numpy::ndarray::Array1;
+    use ndarray::array;
+    use ndarray::Array1;
     use rand::RngCore;
 
     use crate::random::{RandomGenerator, TestDummyRng};

--- a/src/operators/crossover/uniform_binary.rs
+++ b/src/operators/crossover/uniform_binary.rs
@@ -59,7 +59,7 @@ impl CrossoverOperator for UniformBinaryCrossover {
 mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use numpy::ndarray::{array, Array1};
+    use ndarray::{array, Array1};
     use rand::RngCore;
 
     /// A controlled fake random generator that returns predetermined values for `gen_proability()`.

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use numpy::ndarray::Axis;
+use ndarray::Axis;
 
 use crate::{
     algorithms::AlgorithmContext,

--- a/src/operators/mutation/binflip.rs
+++ b/src/operators/mutation/binflip.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*; // Brings in BitFlipMutation and related types.
     use crate::genetic::PopulationGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use numpy::ndarray::array;
+    use ndarray::array;
     use rand::RngCore;
 
     /// A fake RandomGenerator for testing that always returns `true` for `gen_bool`.

--- a/src/operators/mutation/gaussian.rs
+++ b/src/operators/mutation/gaussian.rs
@@ -50,7 +50,7 @@ mod tests {
     use super::*;
     use crate::genetic::PopulationGenes;
     use crate::random::MOORandomGenerator;
-    use numpy::ndarray::array;
+    use ndarray::array;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 

--- a/src/operators/mutation/swap.rs
+++ b/src/operators/mutation/swap.rs
@@ -46,7 +46,7 @@ mod tests {
     use super::*;
     use crate::genetic::PopulationGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use numpy::ndarray::array;
+    use ndarray::array;
     use rand::RngCore;
 
     /// A controlled fake RandomGenerator that returns predetermined values for `gen_range_usize`.

--- a/src/operators/sampling/permutation.rs
+++ b/src/operators/sampling/permutation.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use numpy::ndarray::Array1;
+use ndarray::Array1;
 use pymoors_macros::py_operator;
 
 use crate::operators::{GeneticOperator, IndividualGenes, SamplingOperator};

--- a/src/operators/survival/agemoea.rs
+++ b/src/operators/survival/agemoea.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 
 use ndarray_stats::QuantileExt;
-use numpy::ndarray::{stack, Array1, Array2, ArrayView1, Axis};
+use ndarray::{stack, Array1, Array2, ArrayView1, Axis};
 
 use crate::algorithms::AlgorithmContext;
 use crate::genetic::PopulationFitness;

--- a/src/operators/survival/nsga2.rs
+++ b/src/operators/survival/nsga2.rs
@@ -104,7 +104,7 @@ pub fn crowding_distance(population_fitness: &PopulationFitness) -> Array1<f64> 
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use numpy::ndarray::{array, concatenate, Array2, Axis};
+    use ndarray::{array, concatenate, Array2, Axis};
 
     use crate::genetic::Population;
     use crate::random::NoopRandomGenerator;


### PR DESCRIPTION
This is needed to do #78 , `moors` will not depend on `numpy`, just in `ndarray`. Replace `use numpy::ndarray::` to just `use ndarray::` in the places where it can be done without affecting python communication 